### PR TITLE
patch: add rhbz numbers from commits

### DIFF
--- a/rdopkg/actions.py
+++ b/rdopkg/actions.py
@@ -920,7 +920,7 @@ def check_new_patches(version, local_patches_branch,
         head = patches_branch
 
     version_tag = guess.version2tag(version, version_tag_style)
-    patches = git.get_commits(version_tag, head)
+    patches = git.get_commit_bzs(version_tag, head)
     spec = specfile.Spec()
 
     n_git_patches = len(patches)
@@ -933,7 +933,13 @@ def check_new_patches(version, local_patches_branch,
         patches = (flatten(_partition_patches(patches, ignore_regex)))
         n_ignore_patches = n_git_patches - len(patches)
 
-    patch_subjects = [subject for hash, subject in patches]
+    patch_subjects = []
+    for hash, subject, bzs in patches:
+        subj = subject
+        bzstr = ' '.join(map(lambda x:'rhbz#%s' % x, bzs))
+        if bzstr != '':
+            subj += ' (%s)' % bzstr
+        patch_subjects.append(subj)
     n_base_patches = n_skip_patches + n_spec_patches
     log.debug("Total patches in git:%d spec:%d skip:%d ignore:%d" % (
               n_git_patches, n_spec_patches, n_skip_patches, n_ignore_patches))

--- a/rdopkg/actions.py
+++ b/rdopkg/actions.py
@@ -455,18 +455,22 @@ def _print_patch_log(patches, tag, n_excluded):
     if n_patches <= 0:
         return
     ei = n_patches - n_excluded
-    for hsh, title in patches:
+    for hsh, title, bzs in patches:
         if ei > 0:
             chsh = log.term.green(hsh)
         else:
             chsh = log.term.red(hsh)
-        print("%s  %s" % (chsh, title))
+        bzlog = ' '.join(map(lambda x:'rhbz#%s' % x, bzs))
+        patchlog = "%s  %s" % (chsh, title)
+        if bzlog != '':
+            patchlog += ' (%s)' % bzlog
+        print(patchlog)
         ei -= 1
 
 
 def show_patch_log(version, patches_branch, version_tag_style=None):
     tag = guess.version2tag(version, version_tag_style)
-    patches = git.get_commits(tag, patches_branch)
+    patches = git.get_commit_bzs(tag, patches_branch)
     spec = specfile.Spec()
     n_excluded = spec.get_n_excluded_patches()
     print("\nPatches branch {t.bold}{pb}{t.normal} is at version {t.bold}"


### PR DESCRIPTION
With this change, `rdopkg patch` will check each "-patches" commit for any rhbz numbers and add them to the %changelog entries.

Resolves: https://github.com/openstack-packages/rdopkg/issues/21