### PR TITLE
PLEASE USE `git review`, NOT PULL REQUESTS

### DIFF
--- a/use_git_review
+++ b/use_git_review
@@ -1,0 +1,5 @@
+rdopkg now lives on review.rdoproject.org, please use
+
+    git review
+
+to submit reviews.


### PR DESCRIPTION
to submit rdopkg patches. rdopkg now lives on review.rdoproject.org and
mirrors back to github.

Please use `git review` instead of github Pull Requests.

Bugs are still managed through github Issues tracker:

https://github.com/openstack-packages/rdopkg/issues

to submit reviews.