### PR TITLE
HACKING.md: correct tests command

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -131,7 +131,7 @@ If you're doing non-trivial change, I strongly suggest adding unit tests.
 
 Either way, make sure *existing unit tests pass* after your change by running
 
-    py.test
+    py.test tests/
 
 until automatic gating is done on the repo.
 


### PR DESCRIPTION
If the user has a virtualenv dir in the current working directory, then `py.test` will scan that directory, trying to test files that we don't want to test.

Update the recommended `py.test` command so that we only test rdopkg.